### PR TITLE
fix lintian spelling-error-in-binary

### DIFF
--- a/src/help.c
+++ b/src/help.c
@@ -284,7 +284,7 @@ void Usage()
 
 
   PhyML_Printf("%s\n\t--no_memory_check%s\n",BOLD,FLAT);
-  PhyML_Printf("\t\t%sNo interactive question for memory usage (for running in batch mode). Normal ouput otherwise.\n",FLAT);
+  PhyML_Printf("\t\t%sNo interactive question for memory usage (for running in batch mode). Normal output otherwise.\n",FLAT);
   PhyML_Printf("\n");
 
   #ifndef PHYTIME


### PR DESCRIPTION
Just a single char ... ouput -> output

https://lintian.debian.org/full/debian-med-packaging@lists.alioth.debian.org.html#phyml
