### PR TITLE
Removed the last element of the list after reading weight file

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -1980,7 +1980,7 @@ t_tree *Read_Tree_File(option *io)
 
 scalar_dbl *Read_Io_Weights(option *io)
 {
-  scalar_dbl *w,*ori;
+  scalar_dbl *w,*ori,*prev = NULL;
   double val;
 
   assert(io->weight_file);
@@ -1995,11 +1995,17 @@ scalar_dbl *Read_Io_Weights(option *io)
       if(fscanf(io->fp_weight_file,"%lf,",&val) == EOF) break;      
       w->v = (phydbl)val;
       w->next = (scalar_dbl *)mCalloc(1,sizeof(scalar_dbl));
+      prev = w;
       w = w->next;
     }
   while(1);
 
-  w->next = NULL;
+  /* Remove the last allocated and empty element of the list */
+  if(prev !=NULL && prev->next != NULL)
+    {
+      Free(prev->next);
+      prev->next=NULL;
+    }
 
   fclose(io->fp_weight_file);
   


### PR DESCRIPTION
Hi Stephane,

We tested the use of an input weight file, and found out that there seems to be a problem with the number of elements in the weight file.

Example with the following files:
* [weights.txt](https://github.com/stephaneguindon/phyml/files/347947/weights.txt)
* [align.txt](https://github.com/stephaneguindon/phyml/files/347952/align.txt)

```
phyml -i align.txt --weights weights.txt
```

```
== Sequence length (4) differs from number of weights (5).
```

There seems to be an extra allocated `scalar_dbl` in the function `Read_Io_Weights` (io.c) once the last weight has been seen.

I propose the following changes, but I don't know if you would have done it that way.