### PR TITLE
Changed call to Free_Cseq to Free_Calign

### DIFF
--- a/src/invitee.c
+++ b/src/invitee.c
@@ -688,7 +688,7 @@ void PhyTime_XML(char *xml_file)
   Free_Tree_Pars(tree);
   Free_Tree_Lk(tree);
   Free_Tree(tree);
-  Free_Cseq(cdata);
+  Free_Calign(cdata);
   Free_Model(mod);
   if(io -> fp_in_align)   fclose(io -> fp_in_align);
   if(io -> fp_in_tree)    fclose(io -> fp_in_tree);


### PR DESCRIPTION
This is based on the change made in https://github.com/stephaneguindon/phyml/commit/3b3d7a59c96724b076d005303bbc11c9651d36a4#diff-556ba3c2d73f83262c557a0ea684aeceL361

I don't know if this is correct!  But it does at least solve the non-compilation problem in #34.

Also, there are two calls to `Free_Cseq` in the source code in the `v3.2.20160530` tarballs: the one changed here, in `src/invitees.c` and another on line 259 in `src/times.c`. The latter seems to have also been changed to `Free_Calign` in (the new home of `TIMES_main`) `src/main.c`. So the change in this pr might be correct.

Fixes #34 (hopefully).
