### PR TITLE
Remove include malloc.h (fixes #52)

### DIFF
--- a/src/utilities.h
+++ b/src/utilities.h
@@ -28,8 +28,6 @@ the GNU public licence. See http://www.opensource.org for details.
 #include <float.h>
 #include <assert.h>
 #include <stdbool.h>
-/* #include <malloc/malloc.h> */
-#include <malloc.h>
 
 #if (defined(__AVX__))
 #include <xmmintrin.h>


### PR DESCRIPTION
 - `malloc`, `posix_memalign`, `calloc` etc are already declared via`#include <stdlib.h>`
 - including `malloc/malloc.h` would declare `malloc_zone_create` and friends
 - including `malloc.h` offers `malloc_stats` and other internal access