### PR TITLE
Allow multiple executables to be built at once

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -117,52 +117,28 @@ AM_CONDITIONAL([WANT_WIN], [test "$enable_win" = yes])
 
 AC_ARG_ENABLE([phytime],[AS_HELP_STRING([--enable-phytime],[Compile PhyTime])],[phytime=yes],[phytime=no])
 AM_CONDITIONAL([WANT_PHYTIME], [test "$phytime" = yes])
-if test "$phytime" = yes; then
-   AC_DEFINE([PHYTIME],[1],[PHYTIME tag on])
-fi
 
 AC_ARG_ENABLE([phyml],[AS_HELP_STRING([--enable-phyml],[Compile PhyML])],[phyml=yes],[phyml=no])
 AM_CONDITIONAL([WANT_PHYML], [test "$phyml" = yes])
-if test "$phyml" = yes; then
-   AC_DEFINE([PHYML],[1],[PHYML tag on])
-fi
 
 
 AC_ARG_ENABLE([rwrap],[AS_HELP_STRING([--enable-rwrap],[Compile Rwrap])],[rwrap=yes],[rwrap=no])
 AM_CONDITIONAL([WANT_RWRAP], [test "$rwrap" = yes])
-if test "$rwrap" = yes; then
-   AC_DEFINE([RWRAP],[1],[RWRAP tag on])
-fi
 
 AC_ARG_ENABLE([rf],[AS_HELP_STRING([--enable-rf],[Compile RF])],[rf=yes],[rf=no])
 AM_CONDITIONAL([WANT_RF], [test "$rf" = yes])
-if test "$rf" = yes; then
-   AC_DEFINE([RF],[1],[RF tag on])
-fi
 
 AC_ARG_ENABLE([test],[AS_HELP_STRING([--enable-test],[Compile test])],[test=yes],[test=no])
 AM_CONDITIONAL([WANT_TEST], [test "$test" = yes])
-if test "$test" = yes; then
-   AC_DEFINE([TEST],[1],[TEST tag on])
-fi
 
 AC_ARG_ENABLE([evolve],[AS_HELP_STRING([--enable-evolve],[Compile evolve])],[evolve=yes],[evolve=no])
 AM_CONDITIONAL([WANT_EVOLVE], [test "$evolve" = yes])
-if test "$evolve" = yes; then
-   AC_DEFINE([EVOLVE],[1],[EVOLVE tag on])
-fi
 
 AC_ARG_ENABLE([phyrex],[AS_HELP_STRING([--enable-phyrex],[Compile phyrex])],[phyrex=yes],[phyrex=no])
 AM_CONDITIONAL([WANT_PHYREX], [test "$phyrex" = yes])
-if test "$phyrex" = yes; then
-   AC_DEFINE([PHYREX],[1],[PHYREX tag on])
-fi
 
 AC_ARG_ENABLE([phyrexsim],[AS_HELP_STRING([--enable-phyrexsim],[Compile phyrexsim])],[phyrexsim=yes],[phyrexsim=no])
 AM_CONDITIONAL([WANT_PHYREXSIM], [test "$phyrexsim" = yes])
-if test "$phyrexsim" = yes; then
-   AC_DEFINE([PHYREXSIM],[1],[PHYREXSIM tag on])
-fi
 
 dnl AS_IF([test "x$enable_phyrex" = "xyes"],[PKG_CHECK_MODULES([GTK], [gtk+-3.0])])
 dnl AS_IF([test "x$enable_phyrex" = "xyes"],[PKG_CHECK_MODULES([CAIRO], [cairo])])
@@ -173,27 +149,6 @@ dnl AM_PATH_GTK_3_0(,,AC_MSG_ERROR(windoe-default needs GTK+-3))
 
 AC_ARG_ENABLE([date],[AS_HELP_STRING([--enable-date],[Compile date])],[date=yes],[date=no])
 AM_CONDITIONAL([WANT_DATE], [test "$date" = yes])
-if test "$date" = yes; then
-   AC_DEFINE([DATE],[1],[DATE tag on])
-fi
-
-if test "$phytime" = no; then
-if test "$rwrap" = no; then
-if test "$test" = no; then
-if test "$rf" = no; then
-if test "$evolve" = no; then
-if test "$phyrex" = no; then
-if test "$phyrexsim" = no; then
-if test "$date" = no; then
-   AC_DEFINE([PHYML],[1],[PHYML tag on])
-fi
-fi
-fi
-fi
-fi
-fi
-fi
-fi
 
 AC_CONFIG_FILES([Makefile src/Makefile doc/Makefile])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,58 +2,36 @@
 
 
 DEFS = $(REVISION)
-
+bin_PROGRAMS = 
 if WANT_PHYML
-bin_PROGRAMS = phyml
-PROG = PHYML
-else
+bin_PROGRAMS += phyml
+endif
 if WANT_PHYTIME
-bin_PROGRAMS = phytime
-PROG = PHYTIME
-else
+bin_PROGRAMS += phytime
+endif
 if WANT_RF
-bin_PROGRAMS = rf
-PROG = RF
-else 
+bin_PROGRAMS += rf
+endif
 if WANT_MPI
-bin_PROGRAMS = phyml-mpi
-PROG = PHYML
-else
+bin_PROGRAMS += phyml-mpi
+endif
 if WANT_WIN
-bin_PROGRAMS = phyml-windows
-PROG = PHYML
-else
+bin_PROGRAMS += phyml-windows
+endif
 if WANT_TEST
-bin_PROGRAMS = test
-PROG = TEST
-else
+bin_PROGRAMS += test
+endif
 if WANT_EVOLVE
-bin_PROGRAMS = evolve
-PROG = EVOLVE
-else
+bin_PROGRAMS += evolve
+endif
 if WANT_PHYREX
-bin_PROGRAMS = phyrex
-PROG = PHYREX
-else
+bin_PROGRAMS += phyrex
+endif
 if WANT_PHYREXSIM
-bin_PROGRAMS = phyrexsim
-PROG = PHYREXSIM
-else
+bin_PROGRAMS += phyrexsim
+endif
 if WANT_DATE
-bin_PROGRAMS = date
-PROG = DATE
-else
-bin_PROGRAMS = phyml
-PROG = PHYML
-endif
-endif
-endif
-endif
-endif
-endif
-endif
-endif
-endif
+bin_PROGRAMS += date
 endif
 
 
@@ -90,8 +68,8 @@ sse.c sse.h\
 avx.c avx.h\
 ancestral.c ancestral.h\
 xml.c xml.h
-phytime_LDADD = -lm
-else 
+phytime_CFLAGS = -DPHYTIME $(AM_CFLAGS)
+endif
 # if WANT_RWRAP
 # lib_LTLIBRARIES = librwrap.la
 # librwrap_la_SOURCES = main.c \
@@ -123,7 +101,6 @@ else
 # xml.c xml.h\
 # mixt.c mixt.h\
 # rwrapper.c rwrapper.h
-# librwrap_la_LIBADD = -lm
 # librwrap_la_LDFLAGS = -I/usr/share/R/include -shared -module -flat_namespace
 # librwrap_la_CFLAGS=-std=gnu99 -fPIC -Wl,-z,defs
 # else 
@@ -156,8 +133,8 @@ tbe.c tbe.h \
 ancestral.c ancestral.h\
 sse.c sse.h\
 avx.c avx.h
-rf_LDADD = -lm
-else
+rf_CFLAGS = -DRF $(AM_CFLAGS)
+endif
 if WANT_MPI
 phyml_mpi_SOURCES = main.c \
 utilities.c  utilities.h\
@@ -187,8 +164,8 @@ sse.c sse.h\
 avx.c avx.h\
 ancestral.c ancestral.h\
 mpi_boot.c mpi_boot.h
-phyml_mpi_LDADD = -lm
-else
+phyml_mpi_CFLAGS = -DPHYML $(AM_CFLAGS)
+endif
 if WANT_WIN
 phyml_windows_SOURCES = main.c \
 utilities.c  utilities.h\
@@ -222,8 +199,7 @@ sse.c sse.h\
 avx.c avx.h\
 ancestral.c ancestral.h\
 date.c date.h
-phyml_windows_LDADD = -lm
-else
+endif
 if WANT_TEST
 test_SOURCES = main.c \
 utilities.c  utilities.h\
@@ -257,8 +233,8 @@ sse.c sse.h\
 avx.c avx.h\
 ancestral.c ancestral.h\
 date.c date.h
-test_LDADD = -lm
-else
+test_CFLAGS = -DTEST $(AM_CFLAGS)
+endif
 if WANT_EVOLVE
 evolve_SOURCES = main.c\
 utilities.c  utilities.h\
@@ -288,8 +264,8 @@ nexus.c nexus.h\
 init.c init.h\
 xml.c xml.h\
 mixt.c mixt.h
-evolve_LDADD = -lm 
-else
+evolve_CFLAGS = -DEVOLVE $(AM_CFLAGS)
+endif
 if WANT_PHYREX
 phyrex_SOURCES = main.c\
 utilities.c  utilities.h\
@@ -328,8 +304,8 @@ slfv.c slfv.h\
 rw.c rw.h\
 rrw.c rrw.h\
 ibm.c ibm.h
-phyrex_LDADD = -lm 
-else
+phyrex_CFLAGS = -DPHYREX $(AM_CFLAGS)
+endif
 if WANT_PHYREXSIM
 phyrexsim_SOURCES = main.c\
 utilities.c  utilities.h\
@@ -364,8 +340,8 @@ sse.c sse.h\
 avx.c avx.h\
 ancestral.c ancestral.h\
 phyrex.c phyrex.h
-phyrexsim_LDADD = -lm
-else
+phyrexsim_CFLAGS = -DPHYREXSIM $(AM_CFLAGS)
+endif
 if WANT_DATE
 date_SOURCES = main.c \
 utilities.c  utilities.h\
@@ -396,8 +372,8 @@ xml.c xml.h\
 tbe.c tbe.h \
 mixt.c mixt.h\
 date.c date.h
-date_LDADD = -lm
-else
+date_CFLAGS = -DDATE $(AM_CFLAGS)
+endif
 phyml_SOURCES = main.c \
 utilities.c  utilities.h\
 optimiz.c  optimiz.h\
@@ -425,16 +401,7 @@ avx.c avx.h\
 tbe.c tbe.h \
 ancestral.c ancestral.h \
 mixt.c mixt.h
-phyml_LDADD = -lm
-endif
-endif
-endif
-endif
-endif
-endif
-endif
-endif
-endif
+phyml_CFLAGS = -DPHYML $(AM_CFLAGS)
 
 
 all-am:	intro $(bin_PROGRAMS)


### PR DESCRIPTION
I was working on getting phyml added into the [spack](https://spack.io/) package manager and wanted to be able to compile multiple executables with one configure invocation.

I _think_ this preserves the functionality of the original setup, it just results in multiple executables being output at the end of it if so specified by the configure invocation.